### PR TITLE
Add multi-SRA-per-pod weebill Argo workflow

### DIFF
--- a/cloud/argo/runlists_multi_sra/multi_test5.csv
+++ b/cloud/argo/runlists_multi_sra/multi_test5.csv
@@ -1,0 +1,3 @@
+pod_accessions,batch_name,ephemeral_storage_mb,pod_id,n_accessions,total_mbytes
+SRR36222975 SRR32600033 SRR36782522,multi_test5,5866,0,3,433
+SRR31284847 ERR16024520,multi_test5,5226,1,2,113

--- a/cloud/argo/slow_argo_submission_multi.py
+++ b/cloud/argo/slow_argo_submission_multi.py
@@ -60,6 +60,9 @@ if __name__ == '__main__':
         help='CSV with headers, at least pod_accessions (space separated accessions), '
              'batch_name and ephemeral_storage_mb')
     parent_parser.add_argument('--workflow-template', required=True, help='workflow template to use')
+    parent_parser.add_argument('--reference-s3-uri', required=True,
+        help='s3:// URI of the weebill .sylref reference DB, node-cached and read by '
+             '`weebill sketch --reference` to write .sylspr sketches. Same for the whole batch.')
     parent_parser.add_argument('--sleep-interval', type=int, help='sleep this many seconds between submissions', default=60 * 5)
     parent_parser.add_argument('--min-running-pending-file', help='only submit when the number of jobs is below this (a number in a file)')
     parent_parser.add_argument('--batch-size', type=int, help='submit this many pods each time')
@@ -177,6 +180,7 @@ if __name__ == '__main__':
                         "{{workflow.parameters.SRA_accession_num}}", row['pod_accessions']).replace(
                         'generateName: singlem-', f'generateName: multi-{first_acc}-').replace(
                         "{{workflow.parameters.ephemeral_storage_mb}}", str(row['ephemeral_storage_mb'])).replace(
+                        "{{workflow.parameters.reference_s3_uri}}", args.reference_s3_uri).replace(
                         "{{workflow.parameters.batch_name}}", row['batch_name']))
                 f.flush()
 

--- a/cloud/argo/slow_argo_submission_multi.py
+++ b/cloud/argo/slow_argo_submission_multi.py
@@ -1,0 +1,202 @@
+#!/usr/bin/env python3
+
+###############################################################################
+#
+#    Copyright (C) 2020 Ben Woodcroft
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+###############################################################################
+
+# Throttled Argo submission for the multi-SRA-per-pod weebill workflow
+# (sra_multi_workflow_template.yaml). Each row of the input CSV is one pod that
+# loops over several whole SRA runs. This is the multi-accession sibling of
+# slow_argo_submission_chunked.py; see sra_multi_batch_creation.ipynb for how
+# the CSV is built.
+
+__author__ = "Ben Woodcroft"
+__copyright__ = "Copyright 2020"
+__credits__ = ["Ben Woodcroft"]
+__license__ = "GPL3"
+__maintainer__ = "Ben Woodcroft"
+__email__ = "benjwoodcroft near gmail.com"
+__status__ = "Development"
+
+import argparse
+import logging
+import sys
+import os
+import time
+import extern
+import itertools
+import tempfile
+import queue
+import polars as pl
+
+sys.path = [os.path.join(os.path.dirname(os.path.realpath(__file__)),'..')] + sys.path
+
+def iterable_chunks(iterable, n):
+    '''Given an iterable, return it in chunks of size n. In the last chunk, the
+    remaining space is replaced by None entries.
+    '''
+    args = [iter(iterable)] * n
+    return itertools.zip_longest(*args, fillvalue=None)
+
+if __name__ == '__main__':
+    parent_parser = argparse.ArgumentParser()
+
+    parent_parser.add_argument('--input-runlist-csv', required=True,
+        help='CSV with headers, at least pod_accessions (space separated accessions), '
+             'batch_name and ephemeral_storage_mb')
+    parent_parser.add_argument('--workflow-template', required=True, help='workflow template to use')
+    parent_parser.add_argument('--sleep-interval', type=int, help='sleep this many seconds between submissions', default=60 * 5)
+    parent_parser.add_argument('--min-running-pending-file', help='only submit when the number of jobs is below this (a number in a file)')
+    parent_parser.add_argument('--batch-size', type=int, help='submit this many pods each time')
+    parent_parser.add_argument('--batch-size-file', help='read from a file which is just a number - submit this many pods each time')
+    parent_parser.add_argument('--blacklist', help='Drop these accessions (one per line) from each pod; pods left with no accessions are skipped. Use to resume without redoing finished runs.')
+
+    parent_parser.add_argument('--dry-run', help='apply the blacklist, print the number of pods to submit, and quit', action="store_true")
+    parent_parser.add_argument('--debug', help='output debug information', action="store_true")
+    parent_parser.add_argument('--quiet', help='only output errors', action="store_true")
+
+    args = parent_parser.parse_args()
+
+    # Setup logging
+    if args.debug:
+        loglevel = logging.DEBUG
+    elif args.quiet:
+        loglevel = logging.ERROR
+    else:
+        loglevel = logging.INFO
+    logging.basicConfig(level=loglevel, format='%(asctime)s %(levelname)s: %(message)s', datefmt='%m/%d/%Y %I:%M:%S %p')
+
+    pods = pl.read_csv(args.input_runlist_csv)
+    logging.info(f"Found {pods.shape[0]} pods from input runlist")
+    for required in ('pod_accessions', 'batch_name', 'ephemeral_storage_mb'):
+        if required not in pods.columns:
+            raise Exception(f"Input CSV is missing required column '{required}'")
+
+    blacklist = set()
+    if args.blacklist:
+        with open(args.blacklist) as f:
+            blacklist = set([s.strip() for s in f.readlines() if s.strip()])
+    logging.info(f"Read {len(blacklist)} blacklist accessions")
+
+    # Build the work queue, dropping blacklisted accessions from each pod and
+    # skipping any pod that ends up empty.
+    num_dropped_accs = 0
+    num_skipped_pods = 0
+    qu = queue.Queue()
+    for e in pods.rows(named=True):
+        accs = str(e['pod_accessions']).split()
+        if blacklist:
+            kept = [a for a in accs if a not in blacklist]
+            num_dropped_accs += len(accs) - len(kept)
+            accs = kept
+        if not accs:
+            num_skipped_pods += 1
+            continue
+        e = dict(e)
+        e['pod_accessions'] = ' '.join(accs)
+        qu.put(e)
+    total_to_submit = qu.qsize()
+    logging.info(
+        f"Found {total_to_submit} pods to submit after blacklisting "
+        f"({num_dropped_accs} accessions dropped, {num_skipped_pods} pods fully skipped)")
+
+    if args.dry_run:
+        sys.exit(0)
+
+    if args.batch_size:
+        batch_size = args.batch_size
+    elif args.batch_size_file:
+        batch_size = 0
+    else:
+        raise Exception("Need batch size or batch size file")
+
+    num_submitted = 0
+    while not qu.empty():
+        if args.min_running_pending_file:
+            with open(args.min_running_pending_file) as f:
+                min_running_pending = int(f.read().strip())
+                while True:
+                    try:
+                        # Get workflows not pods because otherwise we don't get the full list
+                        pods_output = extern.run("kubectl get workflows -n argo --no-headers")
+                        running_pending = sum(1 for line in pods_output.splitlines()
+                                              if len(line.split()) >= 3 and line.split()[1] in ('Running', 'Pending'))
+                        logging.info(f"Running/Pending: {running_pending}")
+                        break
+                    except extern.ExternCalledProcessError as e:
+                        logging.warning(f"Failed to get kubectl pod list. Retrying after pause. Error was {e}")
+                        time.sleep(args.sleep_interval)
+                        continue
+                if running_pending >= min_running_pending:
+                    logging.info(f"Found {running_pending} running/pending jobs, need min {min_running_pending} to finish before submitting more")
+                    time.sleep(args.sleep_interval)
+                    continue
+        if args.batch_size_file:
+            with open(args.batch_size_file) as f:
+                prev = batch_size
+                batch_size = int(f.read().strip())
+                if prev != batch_size:
+                    logging.info(f"Changing batch size to {batch_size} pods")
+        chunk = []
+        while not qu.empty() and len(chunk) < batch_size:
+            chunk.append(qu.get())
+
+        # Submit each with argo submit
+        # Keep trying submission, in case of head node failure.
+        for i, iterchunk in enumerate(iterable_chunks(chunk, 50)):
+            iterchunk = [x for x in iterchunk if x is not None]
+
+            with tempfile.NamedTemporaryFile(mode='w') as f:
+                with open(args.workflow_template) as template_file:
+                    template = template_file.read()
+
+                first = True
+                for row in iterchunk:
+                    if first:
+                        first = False
+                    else:
+                        f.write("\n---\n")
+                    # Name the workflow after the pod's first accession (DNS-1123 requires lowercase)
+                    first_acc = row['pod_accessions'].split()[0].lower()
+                    f.write(template.replace(
+                        "{{workflow.parameters.SRA_accession_num}}", row['pod_accessions']).replace(
+                        'generateName: singlem-', f'generateName: multi-{first_acc}-').replace(
+                        "{{workflow.parameters.ephemeral_storage_mb}}", str(row['ephemeral_storage_mb'])).replace(
+                        "{{workflow.parameters.batch_name}}", row['batch_name']))
+                f.flush()
+
+                while True:
+                    try:
+                        os.makedirs("submissions", exist_ok=True)
+                        extern.run(f"argo submit -n argo -o json {f.name} |jq > submissions/multi-{i}-`date +%Y%m%d-%I%M`.argo_submission.json")
+                    except extern.ExternCalledProcessError as e:
+                        logging.warning("Failed to argo submit. Retrying after pause. Error was {}".format(e))
+                        time.sleep(args.sleep_interval)
+                        continue
+
+                    logging.info("Submitted")
+                    break
+
+        num_submitted += len(chunk)
+        logging.info(f"Submitted {num_submitted} out of {total_to_submit} i.e. {round(float(num_submitted)/total_to_submit*100)}%")
+
+        if num_submitted < total_to_submit:
+            logging.info("sleeping ..")
+            time.sleep(args.sleep_interval)
+
+    logging.info("Finished all submissions")

--- a/cloud/argo/slow_argo_submission_multi.py
+++ b/cloud/argo/slow_argo_submission_multi.py
@@ -183,7 +183,7 @@ if __name__ == '__main__':
                 while True:
                     try:
                         os.makedirs("submissions", exist_ok=True)
-                        extern.run(f"argo submit -n argo -o json {f.name} |jq > submissions/multi-{i}-`date +%Y%m%d-%I%M`.argo_submission.json")
+                        extern.run(f"argo submit -n argo -o json {f.name} |jq > submissions/multi-{i}-`date +%Y%m%d-%H%M%S`.argo_submission.json")
                     except extern.ExternCalledProcessError as e:
                         logging.warning("Failed to argo submit. Retrying after pause. Error was {}".format(e))
                         time.sleep(args.sleep_interval)

--- a/cloud/argo/sra_multi_batch_creation.ipynb
+++ b/cloud/argo/sra_multi_batch_creation.ipynb
@@ -150,7 +150,7 @@
   {
    "cell_type": "markdown",
    "id": "e7effb03",
-   "source": "## test5 - tiny submission test: 5 small runs across 2 pods\n\nA minimal dataset to smoke-test end-to-end submission. Picks 5 small SRA runs\n(so downloads are quick) and forces them across **2 pods** via `max_accs_per_pod=3`\n(3 + 2). Writes `runlists_multi_sra/multi_test5.csv`.",
+   "source": "## Submit\n\nEach CSV row becomes one Argo workflow. The `.sylref` reference DB is the same for\nthe whole batch and is passed as one URI (node-cached, not per pod). For a quick\none-off, substitute the columns into `sra_multi_workflow_template.yaml` and `argo submit`:\n\n```\nsed -e \"s|{{workflow.parameters.SRA_accession_num}}|$pod_accessions|\" \\\n    -e \"s|{{workflow.parameters.batch_name}}|$batch_name|\" \\\n    -e \"s|{{workflow.parameters.ephemeral_storage_mb}}|$ephemeral_storage_mb|\" \\\n    -e \"s|{{workflow.parameters.reference_s3_uri}}|s3://woodcrob-sandpiper-us-east-1/references/weebill/gtdb.sylref|\" \\\n    sra_multi_workflow_template.yaml | argo submit -n argo -\n```\n\nFor throttled, resumable submission use `slow_argo_submission_multi.py`, which reads the CSV\nand replaces the same placeholders per pod (with `--blacklist` to drop already-finished\naccessions):\n\n```\n./slow_argo_submission_multi.py \\\n    --input-runlist-csv runlists_multi_sra/multi_test5.csv \\\n    --workflow-template sra_multi_workflow_template.yaml \\\n    --reference-s3-uri s3://woodcrob-sandpiper-us-east-1/references/weebill/gtdb.sylref \\\n    --batch-size 200 --min-running-pending-file min_job_count\n```",
    "metadata": {}
   },
   {

--- a/cloud/argo/sra_multi_batch_creation.ipynb
+++ b/cloud/argo/sra_multi_batch_creation.ipynb
@@ -1,0 +1,182 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "# Create runlist CSVs for the multi-SRA-per-pod weebill workflow\n\nThis notebook builds the CSV files that feed `sra_multi_workflow_template.yaml`.\n\nUnlike the chunked workflow (`prod_workflow_template4.yaml` + `batch_creation 202602.ipynb`),\nhere each **pod processes several whole SRA runs** in a loop (like the Logan workflow),\nwith **no read chunking**. Per accession the pod streams `sracat-rs` reads straight into\n`weebill sketch --merge` via FIFOs (no fastq temp files). To stop a node being swamped when\nmany download-heavy pods land on it at once, we pack accessions into pods with a size budget\nand emit an `ephemeral_storage_mb` request per pod. The k8s scheduler bin-packs pods by that\nrequest, so it will not overcommit a node's local disk.\n\nOutput CSV columns (one row = one pod):\n\n| column | fed into template parameter | meaning |\n| --- | --- | --- |\n| `pod_accessions` | `SRA_accession_num` | space-separated list of accessions the pod loops over |\n| `batch_name` | `batch_name` | S3 output prefix |\n| `ephemeral_storage_mb` | `ephemeral_storage_mb` | requested local disk (MiB) = scheduler size constraint |\n| `pod_id` | (naming only) | 0-based pod index within the batch |\n| `n_accessions` | (info) | number of accessions in the pod |\n| `total_mbytes` | (info) | summed SRA file size of the pod's accessions |"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import polars as pl\n",
+    "import os"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def show_all(df, width=200, max_col_width=True):\n",
+    "    '''Print an entire polars dataframe in the console or notebook output.'''\n",
+    "    with pl.Config() as cfg:\n",
+    "        cfg.set_tbl_cols(-1)\n",
+    "        cfg.set_tbl_rows(-1)\n",
+    "        cfg.set_tbl_width_chars(width)\n",
+    "        if max_col_width or len(df.columns) == 1:\n",
+    "            cfg.set_fmt_str_lengths(width)\n",
+    "        print(df)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Gather the list of metagenomes we need to process\n",
+    "\n",
+    "Same inputs as `batch_creation 202602.ipynb`: the full SRA metadata dump, minus everything\n",
+    "already processed in previous runs."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Read in list of all the metagenomes we need to process\n",
+    "columns = ['acc','releasedate','organism','mbytes','avespotlen','bases','librarylayout']\n",
+    "all_metags = pl.read_csv('~/git/sandpiper/sra_metadata/sra_metadata_20260303.some_columns.csv.gz', has_header=False)\n",
+    "all_metags.columns = columns\n",
+    "all_metags.head(), all_metags.shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Read in list of metagenomes already processed\n",
+    "prev = pl.read_csv('~/m/msingle/mess/193_202502_sra_scrape/find_gz20250402.accessions.uniq.txt', has_header=False)\n",
+    "prev.columns = ['acc']\n",
+    "prev.head(), prev.shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Subtract the two to get the list of metagenomes we still need to process\n",
+    "to_process = all_metags.filter(~pl.col('acc').is_in(prev['acc']))\n",
+    "to_process.head(), to_process.shape"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Pack accessions into pods with a size budget\n\n`mbytes` is the SRA download size. We:\n\n1. Drop runs bigger than `MAX_SINGLE_RUN_MBYTES` (they belong in the chunked workflow, not\n   this whole-run one, and would blow a single pod's disk).\n2. First-fit-decreasing bin-pack the rest into pods, capping both the summed `mbytes`\n   (`MAX_POD_MBYTES`) and the count (`MAX_ACCS_PER_POD`). Large runs end up ~alone; many\n   small runs share a pod.\n3. Set `ephemeral_storage_mb = total_mbytes * STORAGE_SAFETY_FACTOR + STORAGE_HEADROOM_MB`.\n   sracat-rs streams reads straight into `weebill sketch` via FIFOs, so no fastq temp files\n   are written and the disk footprint is essentially just the `.sra` file itself; the small\n   safety factor only covers filesystem overhead and the tiny `.sylspc` sketch outputs. This\n   value is what the k8s scheduler uses to avoid overloading a node."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# --- Packing / sizing parameters -------------------------------------------------\nMAX_SINGLE_RUN_MBYTES = 20000    # skip runs larger than this (~20 GB); use the chunked workflow instead\nMAX_POD_MBYTES        = 30000    # size budget per pod (summed download size)\nMAX_ACCS_PER_POD      = 20       # cap accessions per pod so a pod is not too long-running\nSTORAGE_SAFETY_FACTOR = 2        # local disk vs raw .sra size. sracat-rs streams into weebill (no\n                                 # fastq temp files), so ~1x .sra is enough; 2x is a safe margin.\nSTORAGE_HEADROOM_MB   = 5000     # fixed headroom (working files, .sylspc sketch outputs)\n\n\ndef pack_into_pods(df, batch_name,\n                   max_pod_mbytes=MAX_POD_MBYTES,\n                   max_accs_per_pod=MAX_ACCS_PER_POD,\n                   max_single_run_mbytes=MAX_SINGLE_RUN_MBYTES,\n                   storage_safety_factor=STORAGE_SAFETY_FACTOR,\n                   storage_headroom_mb=STORAGE_HEADROOM_MB):\n    '''First-fit-decreasing bin packing of accessions into pods by mbytes.\n\n    df must have columns 'acc' and 'mbytes'. Returns one row per pod. The caps\n    default to the globals above but can be overridden per call (e.g. a small\n    max_accs_per_pod to force a test batch across several pods).\n    '''\n    runs = (\n        df.select('acc', 'mbytes')\n          .filter(pl.col('mbytes') <= max_single_run_mbytes)\n          .sort('mbytes', descending=True)\n    )\n    print(f\"{runs.height} runs to pack after dropping those > {max_single_run_mbytes} mbytes \"\n          f\"({df.height - runs.height} dropped)\")\n\n    bins = []  # each bin: dict(accs=[...], total=int)\n    for acc, mbytes in runs.iter_rows():\n        placed = False\n        for b in bins:\n            if b['total'] + mbytes <= max_pod_mbytes and len(b['accs']) < max_accs_per_pod:\n                b['accs'].append(acc)\n                b['total'] += mbytes\n                placed = True\n                break\n        if not placed:\n            bins.append({'accs': [acc], 'total': mbytes})\n\n    pods = pl.DataFrame({\n        'pod_id': list(range(len(bins))),\n        'pod_accessions': [' '.join(b['accs']) for b in bins],\n        'n_accessions': [len(b['accs']) for b in bins],\n        'total_mbytes': [b['total'] for b in bins],\n    }).with_columns(\n        pl.lit(batch_name).alias('batch_name'),\n        (pl.col('total_mbytes') * storage_safety_factor + storage_headroom_mb)\n            .cast(pl.Int64).alias('ephemeral_storage_mb'),\n    ).select(\n        'pod_accessions', 'batch_name', 'ephemeral_storage_mb',\n        'pod_id', 'n_accessions', 'total_mbytes',\n    )\n    return pods"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "def generate_and_write_batch(batch_name, to_process, blacklist_accs, num_acc_to_select,\n                             making_batch=True, outdir='runlists_multi_sra', seed=42, **pack_kwargs):\n    '''Choose accessions, pack them into pods, and write the pod CSV.\n\n    Extra keyword args (e.g. max_accs_per_pod) are forwarded to pack_into_pods.\n    '''\n    os.makedirs(outdir, exist_ok=True)\n    csv_path = os.path.join(outdir, f'{batch_name}.csv')\n\n    if making_batch:\n        possible = to_process.filter(~pl.col('acc').is_in(blacklist_accs))\n        print(f\"{possible.height} accessions available after blacklist of {len(blacklist_accs)}\")\n        chosen = possible.sample(min(num_acc_to_select, possible.height), seed=seed)\n        pods = pack_into_pods(chosen, batch_name, **pack_kwargs)\n        # randomise pod order so big and small pods are interleaved on submission\n        pods = pods.sample(fraction=1, seed=seed, shuffle=True)\n        pods.write_csv(csv_path)\n        print(f\"Wrote {pods.height} pods covering {pods['n_accessions'].sum()} accessions to {csv_path}\")\n\n    return pl.read_csv(csv_path)"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### batch0 - small test batch (a single known accession)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "batch0 = generate_and_write_batch(\n",
+    "    batch_name='multi_batch0',\n",
+    "    to_process=to_process.filter(pl.col('acc') == 'SRR26138773'),\n",
+    "    blacklist_accs=[],\n",
+    "    num_acc_to_select=1,\n",
+    "    making_batch=True,\n",
+    ")\n",
+    "show_all(batch0)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### batch1 - a real batch of many small/medium runs\n",
+    "\n",
+    "Adjust `num_acc_to_select` to control the batch size."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "batch1 = generate_and_write_batch(\n",
+    "    batch_name='multi_batch1',\n",
+    "    to_process=to_process,\n",
+    "    blacklist_accs=[],\n",
+    "    num_acc_to_select=10000,\n",
+    "    making_batch=True,\n",
+    ")\n",
+    "print(batch1.shape)\n",
+    "print(batch1.select('n_accessions', 'total_mbytes', 'ephemeral_storage_mb').describe())\n",
+    "batch1.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e7effb03",
+   "source": "## test5 - tiny submission test: 5 small runs across 2 pods\n\nA minimal dataset to smoke-test end-to-end submission. Picks 5 small SRA runs\n(so downloads are quick) and forces them across **2 pods** via `max_accs_per_pod=3`\n(3 + 2). Writes `runlists_multi_sra/multi_test5.csv`.",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "id": "163df88b",
+   "source": "# 5 small runs (small mbytes so a test download is quick), forced across 2 pods.\ntest_candidates = to_process.filter((pl.col('mbytes') >= 20) & (pl.col('mbytes') <= 300))\ntest5 = generate_and_write_batch(\n    batch_name='multi_test5',\n    to_process=test_candidates,\n    blacklist_accs=[],\n    num_acc_to_select=5,\n    making_batch=True,\n    max_accs_per_pod=3,   # 5 accessions -> 2 pods (3 + 2)\n)\nshow_all(test5)",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Submit\n\nEach CSV row becomes one Argo workflow. For a quick one-off, substitute the columns into\n`sra_multi_workflow_template.yaml` and `argo submit`, e.g. per row:\n\n```\nsed -e \"s|{{workflow.parameters.SRA_accession_num}}|$pod_accessions|\" \\\n    -e \"s|{{workflow.parameters.batch_name}}|$batch_name|\" \\\n    -e \"s|{{workflow.parameters.ephemeral_storage_mb}}|$ephemeral_storage_mb|\" \\\n    sra_multi_workflow_template.yaml | argo submit -n argo -\n```\n\nFor throttled, resumable submission use `slow_argo_submission_multi.py`, which reads the CSV\nand replaces the same three placeholders per pod (with `--blacklist` to drop already-finished\naccessions):\n\n```\n./slow_argo_submission_multi.py \\\n    --input-runlist-csv runlists_multi_sra/multi_batch1.csv \\\n    --workflow-template sra_multi_workflow_template.yaml \\\n    --batch-size 200 --min-running-pending-file min_job_count\n```"
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/cloud/argo/sra_multi_workflow_template.yaml
+++ b/cloud/argo/sra_multi_workflow_template.yaml
@@ -1,0 +1,127 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: singlem-
+  # labels:
+  #   workflows.argoproj.io/archive-strategy: "false"
+  annotations:
+    workflows.argoproj.io/description: |
+      A weebill workflow that processes RAW SRA reads (downloaded with kingfisher),
+      but like the Logan workflow it takes MULTIPLE SRA accessions per pod invocation
+      and loops over them one at a time. Unlike prod_workflow_template4.yaml there is
+      no read chunking here - each accession is processed as a whole run.
+
+      Per accession, with no intermediate fastq written to disk:
+        kingfisher get                          -> $A.sra
+        sracat-rs --single-out singles.fifo ...  > pairs.fifo   (one writer, two FIFOs)
+        weebill sketch --merge --interleaved pairs.fifo --reads singles.fifo
+      sracat-rs streams interleaved paired reads to one FIFO and single/orphan reads
+      to the other; `weebill sketch --merge` sketches each FIFO on its own thread (so
+      both are drained concurrently and neither pipe deadlocks) and merges them into a
+      single compressed sample sketch (.sylspc). See the weebill_build_from_source
+      Dockerfile in cloud/docker for the image.
+
+      To avoid a single node being overwhelmed by many large SRA downloads running in
+      different pods at once, the pod requests ephemeral-storage proportional to the
+      combined size of the accessions it will download (ephemeral_storage_mb). The k8s
+      scheduler bin-packs pods by their resource requests, so a node whose disk is
+      already "full" of ephemeral-storage requests will not have more download-heavy
+      pods scheduled onto it. Because sracat-rs streams (no fastq temp files), the disk
+      footprint is essentially just the .sra file being processed.
+spec:
+  entrypoint: singlem
+
+  podGC:
+    # Pod GC strategy must be one of the following:
+    # * OnPodCompletion - delete pods immediately when pod is completed (including errors/failures)
+    # * OnPodSuccess - delete pods immediately when pod is successful
+    # * OnWorkflowCompletion - delete pods when workflow is completed
+    # * OnWorkflowSuccess - delete pods when workflow is successful
+    # Default: do not delete pods
+    strategy: OnPodSuccess
+    # The duration before pods in the GC queue get deleted. Defaults to 5s
+    # Requires Argo >= 3.5
+    deleteDelayDuration: 1h
+
+  templates:
+    - name: singlem
+      retryStrategy:
+        limit: "2"
+        retryPolicy: "Always"
+      inputs:
+        parameters:
+          - name: SRA_accession_num
+            value: '{{workflow.parameters.SRA_accession_num}}' # Space separated list of SRA accession numbers
+          - name: batch_name
+            value: '{{workflow.parameters.batch_name}}'
+          - name: ephemeral_storage_mb
+            # Requested local disk for this pod, in MiB. Should be >= the combined
+            # download+processing footprint of every accession in SRA_accession_num.
+            # Used purely as a scheduler constraint so nodes are not overloaded.
+            value: '{{workflow.parameters.ephemeral_storage_mb}}'
+      container:
+        image: public.ecr.aws/r8c0q0v5/woodcrob/weebill:latest
+        command: [bash,-c]
+        args: ["
+        echo workflow UID: {{workflow.uid}};
+        echo date: `date`;
+        mkdir -p logs sketches;
+        for A in {{inputs.parameters.SRA_accession_num}}; do A=$A bash -e -o pipefail -c '
+        echo processing $A on `date`;
+        kingfisher get -r $A --output-format-possibilities sra --guess-aws-location --hide-download-progress -m aws-http;
+        ls -lh $A.sra; free -h; df -h;
+        mkfifo $A.pairs.fifo $A.singles.fifo;
+        sracat-rs --single-out $A.singles.fifo $A.sra > $A.pairs.fifo &
+        sracat_pid=$!;
+        weebill sketch --merge --interleaved $A.pairs.fifo --reads $A.singles.fifo -S $A --compressed-database $A -t 4;
+        wait $sracat_pid;
+        mv $A.sylspc sketches/$A.sylspc;
+        rm -f $A.sra $A.pairs.fifo $A.singles.fifo;
+        echo passed $A;
+        find sketches/$A.sylspc -type f -empty -delete;
+        echo workflow UID: {{workflow.uid}};
+        ' 2>&1 | tee -a logs/$A.log;
+        done"
+        ]
+        resources:
+          requests:
+            memory: "4000Mi"
+            cpu: 4 # Whole-run processing like the Logan workflow; sketching is CPU bound.
+            # File-size based scheduling constraint - see the description above.
+            ephemeral-storage: '{{inputs.parameters.ephemeral_storage_mb}}Mi'
+      outputs:
+        artifacts:
+          - name: out-art
+            path: 'sketches'
+            archive: # do not tar.gz the file as argo does by default
+              none: {}
+            s3:
+              endpoint: s3.us-east-1.amazonaws.com
+              bucket: woodcrob-sandpiper-us-east-1
+              key: '{{workflow.parameters.batch_name}}/sketches/{{workflow.uid}}'
+              region: us-east-1
+              # The following fields are secret selectors.
+              # They reference the k8s secret named 'my-s3-credentials'.
+              # This secret is expected to have the keys 'accessKey' and 'secretKey',
+              # containing the base64 encoded credentials to the bucket.
+              accessKeySecret:
+                name: my-s3-credentials
+                key: accessKey
+              secretKeySecret:
+                name: my-s3-credentials
+                key: secretKey
+          - name: log-art
+            path: 'logs'
+            archive: # do not tar.gz the file as argo does by default
+              none: {}
+            s3:
+              endpoint: s3.us-east-1.amazonaws.com
+              bucket: woodcrob-sandpiper-us-east-1
+              key: '{{workflow.parameters.batch_name}}/logs/{{workflow.uid}}'
+              region: us-east-1
+              accessKeySecret:
+                name: my-s3-credentials
+                key: accessKey
+              secretKeySecret:
+                name: my-s3-credentials
+                key: secretKey

--- a/cloud/argo/sra_multi_workflow_template.yaml
+++ b/cloud/argo/sra_multi_workflow_template.yaml
@@ -14,12 +14,21 @@ metadata:
       Per accession, with no intermediate fastq written to disk:
         kingfisher get                          -> $A.sra
         sracat-rs --single-out singles.fifo ...  > pairs.fifo   (one writer, two FIFOs)
-        weebill sketch --merge --interleaved pairs.fifo --reads singles.fifo
+        weebill sketch --merge --reference $REF --interleaved pairs.fifo --reads singles.fifo -d $A
       sracat-rs streams interleaved paired reads to one FIFO and single/orphan reads
       to the other; `weebill sketch --merge` sketches each FIFO on its own thread (so
       both are drained concurrently and neither pipe deadlocks) and merges them into a
-      single compressed sample sketch (.sylspc). See the weebill_build_from_source
-      Dockerfile in cloud/docker for the image.
+      single reference-compressed sample sketch (.sylspr). See the
+      weebill_build_from_source Dockerfile in cloud/docker for the image.
+
+      The .sylspr output is written against a weebill .sylref reference DB. That DB is
+      large but seekable, so rather than baking it into the image or copying it per
+      pod, the fetch-reference initContainer downloads it once per node onto a hostPath
+      cache (reference_s3_uri) shared by every pod on the node; the sketch step then
+      preads only the blocks each sample needs from that local copy.
+
+      Per-accession failure isolation: a failed accession is recorded to a 'failures'
+      artifact and does not abort the pod, so its siblings' sketches still upload.
 
       To avoid a single node being overwhelmed by many large SRA downloads running in
       different pods at once, the pod requests ephemeral-storage proportional to the
@@ -30,6 +39,16 @@ metadata:
       footprint is essentially just the .sra file being processed.
 spec:
   entrypoint: singlem
+
+  # Node-local cache for the weebill .sylref reference DB. hostPath is shared by
+  # all pods on a node, so the reference is downloaded once per node (by the
+  # fetch-reference initContainer) rather than once per pod. DirectoryOrCreate so
+  # the path is created on first use.
+  volumes:
+    - name: ref-cache
+      hostPath:
+        path: /mnt/weebill-ref-cache
+        type: DirectoryOrCreate
 
   podGC:
     # Pod GC strategy must be one of the following:
@@ -59,24 +78,77 @@ spec:
             # download+processing footprint of every accession in SRA_accession_num.
             # Used purely as a scheduler constraint so nodes are not overloaded.
             value: '{{workflow.parameters.ephemeral_storage_mb}}'
+          - name: reference_s3_uri
+            # s3:// URI of the weebill .sylref reference DB. Cached once per node on
+            # a hostPath (see the fetch-reference initContainer below) and read by
+            # `weebill sketch --reference` to write .sylspr sketches directly.
+            value: '{{workflow.parameters.reference_s3_uri}}'
+      # Cache the (large) .sylref on the node's local disk exactly once, shared by
+      # every pod that lands on this node. The .sylref is seekable, so the sketch
+      # step reads only the blocks it needs via pread from this local copy.
+      initContainers:
+        - name: fetch-reference
+          image: public.ecr.aws/r8c0q0v5/woodcrob/weebill:latest
+          volumeMounts:
+            - name: ref-cache
+              mountPath: /refcache
+              # read-write: this container populates the cache
+          env:
+            - name: AWS_DEFAULT_REGION
+              value: us-east-1
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: my-s3-credentials
+                  key: accessKey
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: my-s3-credentials
+                  key: secretKey
+          command: [bash, -c]
+          args:
+            - |
+              set -eo pipefail
+              REF_URI='{{inputs.parameters.reference_s3_uri}}'
+              REF="/refcache/$(basename "$REF_URI")"
+              mkdir -p /refcache
+              # Serialise across pods that start on this node at the same time, so
+              # the reference is downloaded once. flock is held for the whole block.
+              exec 9>/refcache/.download.lock
+              flock 9
+              if [ -s "$REF" ]; then
+                echo "Reference already cached: $REF"
+              else
+                echo "Downloading $REF_URI -> $REF"
+                aws s3 cp "$REF_URI" "$REF.tmp" --quiet
+                mv "$REF.tmp" "$REF"
+              fi
+              ls -lh "$REF"
       container:
         image: public.ecr.aws/r8c0q0v5/woodcrob/weebill:latest
+        volumeMounts:
+          - name: ref-cache
+            mountPath: /refcache
+            readOnly: true
         command: [bash,-c]
         args: ["
         echo workflow UID: {{workflow.uid}};
         echo date: `date`;
+        REF=/refcache/`basename {{inputs.parameters.reference_s3_uri}}`;
+        ls -lh $REF;
         mkdir -p logs sketches;
         for A in {{inputs.parameters.SRA_accession_num}}; do
-        A=$A bash -e -o pipefail -c '
+        A=$A REF=$REF bash -e -o pipefail -c '
         echo processing $A on `date`;
         kingfisher get -r $A --output-format-possibilities sra --guess-aws-location --hide-download-progress -m aws-http;
         ls -lh $A.sra; free -h; df -h;
         mkfifo $A.pairs.fifo $A.singles.fifo;
         sracat-rs --single-out $A.singles.fifo $A.sra > $A.pairs.fifo &
         sracat_pid=$!;
-        weebill sketch --merge --interleaved $A.pairs.fifo --reads $A.singles.fifo -S $A --compressed-database $A -t 4;
+        weebill sketch --merge --reference $REF --interleaved $A.pairs.fifo --reads $A.singles.fifo -S $A -d $A -t 4;
         wait $sracat_pid;
-        mv $A.sylspc sketches/$A.sylspc;
+        mv $A.sylspr sketches/$A.sylspr;
         echo passed $A;
         ' 2>&1 | tee -a logs/$A.log;
         status=${PIPESTATUS[0]};

--- a/cloud/argo/sra_multi_workflow_template.yaml
+++ b/cloud/argo/sra_multi_workflow_template.yaml
@@ -63,6 +63,7 @@ spec:
         image: public.ecr.aws/r8c0q0v5/woodcrob/weebill:latest
         command: [bash,-c]
         args: ["
+        set -eo pipefail;
         echo workflow UID: {{workflow.uid}};
         echo date: `date`;
         mkdir -p logs sketches;

--- a/cloud/argo/sra_multi_workflow_template.yaml
+++ b/cloud/argo/sra_multi_workflow_template.yaml
@@ -122,7 +122,9 @@ spec:
             - |
               set -eo pipefail
               REF_URI='{{inputs.parameters.reference_s3_uri}}'
-              REF="/refcache/$(basename "$REF_URI")"
+              # Key the cache on a hash of the FULL URI, not just the basename, so two
+              # different references that share a filename cannot collide on this node.
+              REF="/refcache/$(printf %s "$REF_URI" | sha256sum | cut -c1-16).$(basename "$REF_URI")"
               mkdir -p /refcache
               # Serialise across pods that start on this node at the same time, so
               # the reference is downloaded once. flock is held for the whole block.
@@ -166,7 +168,7 @@ spec:
         args: ["
         echo workflow UID: {{workflow.uid}};
         echo date: `date`;
-        REF=/refcache/`basename {{inputs.parameters.reference_s3_uri}}`;
+        REF=/refcache/`printf %s {{inputs.parameters.reference_s3_uri}} | sha256sum | cut -c1-16`.`basename {{inputs.parameters.reference_s3_uri}}`;
         ls -lh $REF;
         S3=s3://woodcrob-sandpiper-us-east-1/{{inputs.parameters.batch_name}};
         mkdir -p logs sketches;

--- a/cloud/argo/sra_multi_workflow_template.yaml
+++ b/cloud/argo/sra_multi_workflow_template.yaml
@@ -63,11 +63,11 @@ spec:
         image: public.ecr.aws/r8c0q0v5/woodcrob/weebill:latest
         command: [bash,-c]
         args: ["
-        set -eo pipefail;
         echo workflow UID: {{workflow.uid}};
         echo date: `date`;
         mkdir -p logs sketches;
-        for A in {{inputs.parameters.SRA_accession_num}}; do A=$A bash -e -o pipefail -c '
+        for A in {{inputs.parameters.SRA_accession_num}}; do
+        A=$A bash -e -o pipefail -c '
         echo processing $A on `date`;
         kingfisher get -r $A --output-format-possibilities sra --guess-aws-location --hide-download-progress -m aws-http;
         ls -lh $A.sra; free -h; df -h;
@@ -77,11 +77,13 @@ spec:
         weebill sketch --merge --interleaved $A.pairs.fifo --reads $A.singles.fifo -S $A --compressed-database $A -t 4;
         wait $sracat_pid;
         mv $A.sylspc sketches/$A.sylspc;
-        rm -f $A.sra $A.pairs.fifo $A.singles.fifo;
         echo passed $A;
-        find sketches/$A.sylspc -type f -empty -delete;
-        echo workflow UID: {{workflow.uid}};
         ' 2>&1 | tee -a logs/$A.log;
+        status=${PIPESTATUS[0]};
+        if [ $status -ne 0 ]; then echo FAILED $A exit $status | tee -a logs/$A.log; mkdir -p failures; echo $A >> failures/failed_accessions.txt; fi;
+        rm -f $A.sra $A.pairs.fifo $A.singles.fifo;
+        find sketches -type f -empty -delete;
+        echo workflow UID: {{workflow.uid}};
         done"
         ]
         resources:
@@ -119,6 +121,25 @@ spec:
               endpoint: s3.us-east-1.amazonaws.com
               bucket: woodcrob-sandpiper-us-east-1
               key: '{{workflow.parameters.batch_name}}/logs/{{workflow.uid}}'
+              region: us-east-1
+              accessKeySecret:
+                name: my-s3-credentials
+                key: accessKey
+              secretKeySecret:
+                name: my-s3-credentials
+                key: secretKey
+          - name: failures-art
+            # Per-accession failure isolation: a failed accession does not abort the
+            # pod (its siblings' sketches still upload); instead its name is recorded
+            # here. 'failures/' only exists when something failed, so this is optional.
+            path: 'failures'
+            optional: true
+            archive: # do not tar.gz the file as argo does by default
+              none: {}
+            s3:
+              endpoint: s3.us-east-1.amazonaws.com
+              bucket: woodcrob-sandpiper-us-east-1
+              key: '{{workflow.parameters.batch_name}}/failures/{{workflow.uid}}'
               region: us-east-1
               accessKeySecret:
                 name: my-s3-credentials

--- a/cloud/argo/sra_multi_workflow_template.yaml
+++ b/cloud/argo/sra_multi_workflow_template.yaml
@@ -157,6 +157,11 @@ spec:
               secretKeyRef:
                 name: my-s3-credentials
                 key: secretKey
+          # Let the AWS CLI retry transient S3 errors before we treat an upload as failed.
+          - name: AWS_RETRY_MODE
+            value: standard
+          - name: AWS_MAX_ATTEMPTS
+            value: "10"
         command: [bash,-c]
         args: ["
         echo workflow UID: {{workflow.uid}};
@@ -181,11 +186,16 @@ spec:
         ' 2>&1 | tee logs/$A.log;
         status=${PIPESTATUS[0]};
         if [ $status -ne 0 ]; then echo FAILED $A exit $status >> logs/$A.log; fi;
-        aws s3 cp logs/$A.log $S3/logs/$A.log --quiet;
-        if [ $status -eq 0 ]; then aws s3 cp sketches/$A.sylspr $S3/sketches/$A.sylspr --quiet; else aws s3 cp logs/$A.log $S3/failures/$A.log --quiet; fi;
-        rm -f $A.sra $A.pairs.fifo $A.singles.fifo sketches/$A.sylspr;
+        aws s3 cp logs/$A.log $S3/logs/$A.log --quiet || echo WARN log upload failed for $A;
+        if [ $status -eq 0 ]; then
+        if aws s3 cp sketches/$A.sylspr $S3/sketches/$A.sylspr --quiet; then rm -f sketches/$A.sylspr; else echo WARN sketch upload failed for $A - keeping local copy and will exit non-zero to trigger retry; upload_failed=1; fi;
+        else
+        aws s3 cp logs/$A.log $S3/failures/$A.log --quiet || echo WARN failure-log upload failed for $A;
+        fi;
+        rm -f $A.sra $A.pairs.fifo $A.singles.fifo;
         echo workflow UID: {{workflow.uid}};
-        done"
+        done;
+        if [ ${upload_failed:-0} -ne 0 ]; then echo one or more sketch uploads failed - exiting non-zero so Argo retries the pod, which resumes and skips already-uploaded accessions; exit 1; fi"
         ]
         resources:
           requests:

--- a/cloud/argo/sra_multi_workflow_template.yaml
+++ b/cloud/argo/sra_multi_workflow_template.yaml
@@ -27,8 +27,16 @@ metadata:
       cache (reference_s3_uri) shared by every pod on the node; the sketch step then
       preads only the blocks each sample needs from that local copy.
 
-      Per-accession failure isolation: a failed accession is recorded to a 'failures'
-      artifact and does not abort the pod, so its siblings' sketches still upload.
+      Spot-safe, resumable, per-accession outputs. Each sketch and log is uploaded to
+      S3 directly as the accession finishes, NOT via an end-of-pod Argo artifact - so a
+      spot interruption never loses already-completed sketches. At the top of the loop
+      the pod skips any accession whose .sylspr is already in S3, so an Argo retry (on
+      spot loss; retryPolicy Always) resumes at the interrupted accession instead of
+      redoing the whole pod. Outputs, all keyed per accession under {batch_name}/:
+        sketches/$A.sylspr   successful sketch
+        logs/$A.log          log for every accession attempted
+        failures/$A.log      copy of the log for accessions that failed (for diagnosis)
+      A failed accession does not abort the pod, so its siblings still complete.
 
       To avoid a single node being overwhelmed by many large SRA downloads running in
       different pods at once, the pod requests ephemeral-storage proportional to the
@@ -65,7 +73,10 @@ spec:
   templates:
     - name: singlem
       retryStrategy:
-        limit: "2"
+        # Always: retry on node-loss Errors (spot preemption), not just non-zero exits.
+        # Retries are cheap here because the pod skips accessions already uploaded to S3,
+        # so a higher limit just lets a repeatedly-preempted pod keep making progress.
+        limit: "5"
         retryPolicy: "Always"
       inputs:
         parameters:
@@ -131,14 +142,31 @@ spec:
           - name: ref-cache
             mountPath: /refcache
             readOnly: true
+        # S3 credentials for the per-accession uploads below (same secret the
+        # fetch-reference initContainer and the artifact system use).
+        env:
+          - name: AWS_DEFAULT_REGION
+            value: us-east-1
+          - name: AWS_ACCESS_KEY_ID
+            valueFrom:
+              secretKeyRef:
+                name: my-s3-credentials
+                key: accessKey
+          - name: AWS_SECRET_ACCESS_KEY
+            valueFrom:
+              secretKeyRef:
+                name: my-s3-credentials
+                key: secretKey
         command: [bash,-c]
         args: ["
         echo workflow UID: {{workflow.uid}};
         echo date: `date`;
         REF=/refcache/`basename {{inputs.parameters.reference_s3_uri}}`;
         ls -lh $REF;
+        S3=s3://woodcrob-sandpiper-us-east-1/{{inputs.parameters.batch_name}};
         mkdir -p logs sketches;
         for A in {{inputs.parameters.SRA_accession_num}}; do
+        if aws s3 ls $S3/sketches/$A.sylspr >/dev/null 2>&1; then echo skipping $A, already in S3; continue; fi;
         A=$A REF=$REF bash -e -o pipefail -c '
         echo processing $A on `date`;
         kingfisher get -r $A --output-format-possibilities sra --guess-aws-location --hide-download-progress -m aws-http;
@@ -150,11 +178,12 @@ spec:
         wait $sracat_pid;
         mv $A.sylspr sketches/$A.sylspr;
         echo passed $A;
-        ' 2>&1 | tee -a logs/$A.log;
+        ' 2>&1 | tee logs/$A.log;
         status=${PIPESTATUS[0]};
-        if [ $status -ne 0 ]; then echo FAILED $A exit $status | tee -a logs/$A.log; mkdir -p failures; echo $A >> failures/failed_accessions.txt; fi;
-        rm -f $A.sra $A.pairs.fifo $A.singles.fifo;
-        find sketches -type f -empty -delete;
+        if [ $status -ne 0 ]; then echo FAILED $A exit $status >> logs/$A.log; fi;
+        aws s3 cp logs/$A.log $S3/logs/$A.log --quiet;
+        if [ $status -eq 0 ]; then aws s3 cp sketches/$A.sylspr $S3/sketches/$A.sylspr --quiet; else aws s3 cp logs/$A.log $S3/failures/$A.log --quiet; fi;
+        rm -f $A.sra $A.pairs.fifo $A.singles.fifo sketches/$A.sylspr;
         echo workflow UID: {{workflow.uid}};
         done"
         ]
@@ -164,58 +193,6 @@ spec:
             cpu: 4 # Whole-run processing like the Logan workflow; sketching is CPU bound.
             # File-size based scheduling constraint - see the description above.
             ephemeral-storage: '{{inputs.parameters.ephemeral_storage_mb}}Mi'
-      outputs:
-        artifacts:
-          - name: out-art
-            path: 'sketches'
-            archive: # do not tar.gz the file as argo does by default
-              none: {}
-            s3:
-              endpoint: s3.us-east-1.amazonaws.com
-              bucket: woodcrob-sandpiper-us-east-1
-              key: '{{workflow.parameters.batch_name}}/sketches/{{workflow.uid}}'
-              region: us-east-1
-              # The following fields are secret selectors.
-              # They reference the k8s secret named 'my-s3-credentials'.
-              # This secret is expected to have the keys 'accessKey' and 'secretKey',
-              # containing the base64 encoded credentials to the bucket.
-              accessKeySecret:
-                name: my-s3-credentials
-                key: accessKey
-              secretKeySecret:
-                name: my-s3-credentials
-                key: secretKey
-          - name: log-art
-            path: 'logs'
-            archive: # do not tar.gz the file as argo does by default
-              none: {}
-            s3:
-              endpoint: s3.us-east-1.amazonaws.com
-              bucket: woodcrob-sandpiper-us-east-1
-              key: '{{workflow.parameters.batch_name}}/logs/{{workflow.uid}}'
-              region: us-east-1
-              accessKeySecret:
-                name: my-s3-credentials
-                key: accessKey
-              secretKeySecret:
-                name: my-s3-credentials
-                key: secretKey
-          - name: failures-art
-            # Per-accession failure isolation: a failed accession does not abort the
-            # pod (its siblings' sketches still upload); instead its name is recorded
-            # here. 'failures/' only exists when something failed, so this is optional.
-            path: 'failures'
-            optional: true
-            archive: # do not tar.gz the file as argo does by default
-              none: {}
-            s3:
-              endpoint: s3.us-east-1.amazonaws.com
-              bucket: woodcrob-sandpiper-us-east-1
-              key: '{{workflow.parameters.batch_name}}/failures/{{workflow.uid}}'
-              region: us-east-1
-              accessKeySecret:
-                name: my-s3-credentials
-                key: accessKey
-              secretKeySecret:
-                name: my-s3-credentials
-                key: secretKey
+      # No Argo output artifacts: each sketch/log is uploaded to S3 per accession
+      # inside the loop (see the container args), so completed work survives a spot
+      # interruption instead of only being uploaded on whole-pod success.

--- a/cloud/docker/weebill_build_from_source.Dockerfile
+++ b/cloud/docker/weebill_build_from_source.Dockerfile
@@ -1,0 +1,102 @@
+# Image for the multi-SRA-per-pod weebill workflow (sra_multi_workflow_template.yaml).
+#
+# Per accession the workflow does, with NO intermediate fastq on disk:
+#   kingfisher get -> $A.sra
+#   sracat-rs --single-out singles.fifo $A.sra > pairs.fifo   (one writer, two FIFOs)
+#   weebill sketch --merge --interleaved pairs.fifo --reads singles.fifo
+# sracat-rs streams interleaved pairs to one FIFO and single/orphan reads to the
+# other; weebill's --merge sketches every raw input on its own thread (so both
+# FIFOs are drained at once) and merges them into one sample sketch.
+#
+# Build:
+#   docker build -f weebill_build_from_source.Dockerfile . -t woodcrob/weebill
+FROM ubuntu:24.04
+
+RUN apt-get update && apt-get install -y \
+    git \
+    python3 \
+    python3-pip \
+    build-essential \
+    curl \
+    cmake \
+    gcc \
+    make \
+    wget \
+    unzip
+
+# Rust
+RUN curl --proto '=https' --tlsv1.2 https://sh.rustup.rs -sSf | bash -s -- -y
+ENV PATH="/root/.cargo/bin:${PATH}"
+
+# Both weebill and sracat-rs are compiled with `-C target-cpu=native`. This image
+# is built on a worker node of the SAME instance type it runs on (see the
+# cloud/argo nodegroup templates, c7a.*), so native codegen targets the exact CPU
+# and is faster; it would only be unsafe if the image ran on an older CPU.
+
+# weebill (a sylph fork; installed binary is `weebill`). Pin to a commit for
+# reproducibility - bump WEEBILL_COMMIT to update.
+ENV WEEBILL_COMMIT main
+RUN git clone https://github.com/wwood/weebill /tmp/weebill \
+    && cd /tmp/weebill \
+    && git checkout ${WEEBILL_COMMIT} \
+    && RUSTFLAGS="-C target-cpu=native" cargo install --path . --root /usr/local \
+    && rm -rf /tmp/weebill /root/.cargo/registry /root/.cargo/git
+RUN weebill --help
+
+# sracat-rs - built from source (not the prebuilt release) so it too gets
+# `-C target-cpu=native`. It links ncbi-vdb, a conda-provided C library, so the
+# build runs inside the pixi env declared in the sracat-rs repo (which supplies
+# ncbi-vdb, a C/C++ compiler and zlib); build.rs needs CONDA_PREFIX, which
+# `pixi run` sets. SRACAT_VDB_LINK=static links libncbi-vdb.a so the binary is
+# self-contained and relocatable (no libncbi-vdb.so dependency, no conda rpath):
+# we copy just the binary onto the system PATH and discard the pixi env.
+RUN curl -fsSL https://pixi.sh/install.sh | bash
+ENV PATH="/root/.pixi/bin:${PATH}"
+ENV SRACAT_RS_COMMIT main
+RUN git clone https://github.com/wwood/sracat-rs /tmp/sracat-rs \
+    && cd /tmp/sracat-rs \
+    && git checkout ${SRACAT_RS_COMMIT} \
+    && pixi run -- env SRACAT_VDB_LINK=static RUSTFLAGS="-C target-cpu=native" \
+         cargo install --path . --root /usr/local \
+    && rm -rf /tmp/sracat-rs /root/.cache/rattler
+RUN sracat-rs --help
+
+# NCBI VDB config (cloud location reporting) - harmless for local .sra reads,
+# useful if a tool ever resolves an accession directly.
+RUN apt-get install -y uuid-runtime \
+    && mkdir -p /etc/ncbi \
+    && printf '/LIBS/IMAGE_GUID = "%s"\n' `uuidgen` > /etc/ncbi/settings.kfg \
+    && printf '/libs/cloud/report_instance_identity = "true"\n' >> /etc/ncbi/settings.kfg
+
+# kingfisher (SRA/ENA downloader) and its runtime deps
+RUN apt-get install -y python3-requests python3-tqdm aria2 pigz
+RUN pip install --no-dependencies --break-system-packages \
+    bird_tool_utils argparse-manpage-birdtools extern
+RUN pip install --no-dependencies --break-system-packages kingfisher
+
+# AWS CLI (kingfisher aws-http/aws-cp download and, in the workflow, artifact upload)
+RUN cd /tmp && wget "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -O "awscliv2.zip" \
+    && unzip awscliv2.zip \
+    && ./aws/install --bin-dir /usr/local/bin --install-dir /usr/local/aws-cli --update \
+    && rm -rf /tmp/awscliv2.zip /tmp/aws
+
+# Smoke test: exercise the exact download -> sracat-rs -> weebill FIFO pipeline
+# used by the workflow, so a broken image fails the build rather than the queue.
+# The pipeline runs inside `bash -c` so that `&` backgrounds ONLY sracat-rs (the
+# single writer) while weebill reads both FIFOs in the foreground.
+RUN cd /tmp && kingfisher get -r SRR8653040 -m aws-http -f sra --guess-aws-location --hide-download-progress
+RUN cd /tmp && bash -e -o pipefail -c '\
+    mkfifo pairs.fifo singles.fifo; \
+    sracat-rs --single-out singles.fifo SRR8653040.sra > pairs.fifo & \
+    weebill sketch --merge --interleaved pairs.fifo --reads singles.fifo -S SRR8653040 --compressed-database /tmp/SRR8653040 -t 4; \
+    wait; \
+    ls -lh /tmp/SRR8653040.sylspc' \
+    && rm -f /tmp/SRR8653040* /tmp/pairs.fifo /tmp/singles.fifo
+
+# Clean apt to shrink the image
+RUN rm -rf /var/lib/apt/lists/* && apt-get clean
+
+# Flatten to reduce image size
+FROM scratch
+COPY --from=0 / /
+ENV PATH="/usr/local/bin:/root/.cargo/bin:/usr/bin:/bin"

--- a/cloud/docker/weebill_build_from_source.Dockerfile
+++ b/cloud/docker/weebill_build_from_source.Dockerfile
@@ -33,15 +33,21 @@ ENV PATH="/root/.cargo/bin:${PATH}"
 # cloud/argo nodegroup templates, c7a.*), so native codegen targets the exact CPU
 # and is faster; it would only be unsafe if the image ran on an older CPU.
 
-# weebill (a sylph fork; installed binary is `weebill`). Pin to a commit for
-# reproducibility - bump WEEBILL_COMMIT to update.
-ENV WEEBILL_COMMIT main
-RUN git clone https://github.com/wwood/weebill /tmp/weebill \
+# weebill is developed as a branch of the sylph fork at github.com/wwood/sylph;
+# it builds a binary named `weebill` and provides `weebill sketch --merge`, which
+# this workflow depends on. NOTE: `main` (both bluenote-1577/sylph and the
+# wwood/weebill mirror) does NOT have `sketch --merge`, so pin the commit on the
+# add-merge-single-paired branch that does. (Mirrors sylph_build_from_source
+# .Dockerfile, which likewise builds from a wwood/sylph feature branch.)
+ENV WEEBILL_COMMIT c7f780947c762aebf82245557578ce9ff0ca413b
+RUN git clone https://github.com/wwood/sylph /tmp/weebill \
     && cd /tmp/weebill \
     && git checkout ${WEEBILL_COMMIT} \
     && RUSTFLAGS="-C target-cpu=native" cargo install --path . --root /usr/local \
     && rm -rf /tmp/weebill /root/.cargo/registry /root/.cargo/git
 RUN weebill --help
+# Fail the build early if this ref lacks `sketch --merge` (the workflow needs it).
+RUN weebill sketch --help | grep -q -- --merge
 
 # sracat-rs - built from source (not the prebuilt release) so it too gets
 # `-C target-cpu=native`. It links ncbi-vdb, a conda-provided C library, so the

--- a/cloud/docker/weebill_build_from_source.Dockerfile
+++ b/cloud/docker/weebill_build_from_source.Dockerfile
@@ -68,8 +68,10 @@ RUN apt-get install -y uuid-runtime \
     && printf '/LIBS/IMAGE_GUID = "%s"\n' `uuidgen` > /etc/ncbi/settings.kfg \
     && printf '/libs/cloud/report_instance_identity = "true"\n' >> /etc/ncbi/settings.kfg
 
-# kingfisher (SRA/ENA downloader) and its runtime deps
-RUN apt-get install -y python3-requests python3-tqdm aria2 pigz
+# kingfisher (SRA/ENA downloader) and its runtime deps. kingfisher is installed
+# with --no-dependencies, so its imports (incl. pandas, imported at startup) must
+# be provided here explicitly, otherwise `kingfisher get` fails with ModuleNotFoundError.
+RUN apt-get install -y python3-requests python3-tqdm python3-pandas python3-numpy aria2 pigz
 RUN pip install --no-dependencies --break-system-packages \
     bird_tool_utils argparse-manpage-birdtools extern
 RUN pip install --no-dependencies --break-system-packages kingfisher


### PR DESCRIPTION
## What

A new Argo workflow modelled on the **Logan** workflow (multiple SRA accessions per pod, looped) but running **weebill** on **raw SRA reads** like the recent prod workflow. Per accession it streams reads with `sracat-rs` directly into `weebill sketch --merge` through two FIFOs — one for interleaved paired reads, one for single/orphan reads — so **no intermediate fastq hits disk**.

## Files

- **`cloud/argo/sra_multi_workflow_template.yaml`** — the workflow. Loops over a space-separated accession list; `kingfisher get` → `sracat-rs --single-out singles.fifo $A.sra > pairs.fifo &` → `weebill sketch --merge --interleaved pairs.fifo --reads singles.fifo`. Adds an `ephemeral_storage_mb` request derived from the pod's combined SRA file size, so the k8s scheduler won't overpack a node with many large downloads.
- **`cloud/argo/sra_multi_batch_creation.ipynb`** — polars notebook that bin-packs accessions into pods by file size and computes `ephemeral_storage_mb`, plus a `test5` batch.
- **`cloud/argo/runlists_multi_sra/multi_test5.csv`** — generated test dataset: 5 small runs across 2 pods.
- **`cloud/argo/slow_argo_submission_multi.py`** — throttled, resumable submitter (one pod per CSV row; `--blacklist` drops finished accessions).
- **`cloud/docker/weebill_build_from_source.Dockerfile`** — image with weebill and sracat-rs **both compiled `-C target-cpu=native`** (built on the same worker instance type it runs on), kingfisher + awscli, and a baked-in smoke test of the sracat-rs → weebill FIFO pipeline.

## Notes / follow-ups

- No FIFO deadlock: weebill's `--merge` sketches each raw input on its own thread (verified in source), so a single `sracat-rs` writer feeding both pipes is drained concurrently. sracat-rs's `/1`/`/2` interleaved naming is handled by weebill's interleaved parser (strips the suffix).
- `WEEBILL_COMMIT` and `SRACAT_RS_COMMIT` default to `main` — pin for reproducible image builds.
- Image tag `public.ecr.aws/r8c0q0v5/woodcrob/weebill:latest` is assumed; adjust to your registry. Image still needs building/pushing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)